### PR TITLE
Minor changes to markdown files, and update default kernel for remaining example notebooks

### DIFF
--- a/code/TIC_Panel_Example.ipynb
+++ b/code/TIC_Panel_Example.ipynb
@@ -68,9 +68,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "TESS Environment",
    "language": "python",
-   "name": "python3"
+   "name": "tess"
   },
   "language_info": {
    "codemirror_mode": {

--- a/code/cloud_astroquery.ipynb
+++ b/code/cloud_astroquery.ipynb
@@ -206,9 +206,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "TESS Environment",
    "language": "python",
-   "name": "python3"
+   "name": "tess"
   },
   "language_info": {
    "codemirror_mode": {

--- a/code/s3buckets_boto3.ipynb
+++ b/code/s3buckets_boto3.ipynb
@@ -102,9 +102,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "TESS Environment",
    "language": "python",
-   "name": "python3"
+   "name": "tess"
   },
   "language_info": {
    "codemirror_mode": {

--- a/content/Introduction.md
+++ b/content/Introduction.md
@@ -15,7 +15,7 @@ or you can use the links below to learn more.
 <img src="../images/icons/school_black_24dp.svg" style="vertical-align: bottom; width:1.5em; margin-right:0.25em;"/> [Example science tutorials](science-examples.md)
 
 
-**Caution!** The virtual server that runs your personal instance of TIKE will be terminated after ~1 hour of inactivity. At this time, no data you upload or create within TIKE is guaranteed to remain for any duration. It will tend to persist on a best-effort basis, but we strongly encourage you to back up any essential code and data on another system. 
+**Caution!** TIKE computing and storage are limited resources. At this time, no data you upload or create within TIKE is guaranteed to remain for any duration. Files in your home directory (/home/jovyan) will persist on a best-effort basis, but we strongly recommend that you back up any essential code and data to another system.  We encourage users to store large files only sparingly: we will limit the average data volume of user home directories to approximately 25 GB or less, and we will periodically remove excessive data if needed. 
 
 **What's New?** See the [News Page](news.md) for recent updates to TIKE.
 

--- a/content/software-installed.md
+++ b/content/software-installed.md
@@ -7,12 +7,14 @@ TIKE comes pre-installed with a set of Python packages and Linux software which 
 
 ## Pre-installed Python packages
 
+By default, TIKE includes two Python environments, a bare-bones "Python 3" environment and a "TESS" environment containing many packages.  To use the TESS Environment in a notebook, you may have to change the notebook's kernel, either by using the dropdown menu at the upper right of the notebook, or in the top JupyterLab menu (<span style="font-variant:small-caps;">Kernel › Change Kernel...</span>). At this time, the TESS kernel includes the following packages:
+
 * Core scientific packages:
 numpy, scipy, matplotlib, pandas.
 * Core astronomy packages:
 astropy, astroquery, pyvo.
 * Data analysis packages: emcee, george, celerite.
-* TESS-focused packages: lightkurve, eleanor(omitted), astrocut.
+* TESS-focused packages: lightkurve, astrocut.
 * Machine learning: tensorflow, scikit-learn.
 * Cloud tools: awscli, boto3.
 
@@ -29,4 +31,4 @@ Commands which work in a terminal can also be used in a Jupyter notebook by pref
 
 ## Missing your favorite software?
 
-If a package you need is missing from the configuration, we encourage you to [open a GitHub issue](https://github.com/spacetelescope/jupyterhub-deploy/issues/new) or contact the [MAST help desk](mailto:archive@stsci.edu) to suggest the package for inclusion. Please include a brief justification explaining the audience and purpose of the software.
+If a package you need is missing from the configuration, we encourage you to [open a GitHub issue](https://github.com/spacetelescope/jupyterhub-deploy/issues/new) or contact the [MAST help desk](mailto:archive@stsci.edu) to suggest the package for inclusion. Please include a brief justification explaining the audience and purpose of the software. See also: [How to install extra software?](extra-software.md)

--- a/content/what-is-tike.md
+++ b/content/what-is-tike.md
@@ -7,11 +7,29 @@ TIKE uses a web-based platform, called [JupyterHub](https://jupyter.org/hub), wh
 
 ## Who is TIKE for?
 
-This platform is intended for astronomical researchers who use data products from the NASA Kepler and TESS missions in the Mikulski Archive for Space Telescopes (MAST). 
+This platform is intended for astronomical researchers who use data products from the NASA Kepler and TESS missions in the Mikulski Archive for Space Telescopes (MAST).
 
 Frequently used Python packages and graphical tools are available, which enable users to preview and make measurements against these data products without needing to download anything.
 
 There are educational tutorials available that demonstrate how to do research with the TESS and Kepler data.  We use git to pull new and updated Notebooks into your user environment, so if you decide to alter these notebooks for your own purposes (and we hope that you do), you should first make a copy for yourself into your own directory.
+
+## Restarting Your Server
+
+The virtual server that runs your personal instance of TIKE will be terminated after ~1 hour of inactivity, and you will be able to restart it the next time you access TIKE.
+
+You can start and stop your computing server any time from the JupyterHub control panel, which can be accessed from the top menu in JupyterLab (<span style="font-variant:small-caps;">file › Hub Control Panel</span>) or the "Home" tab from JupyterHub pages. For example, this may be useful to obtain an updated and unaltered copy of this tike_content repository, or to clear unwanted changes to the included Python environment(s).
+
+## Useful Information
+
+- TIKE is continually maintained and updated, and as such, you should have modest expectations regarding service uptime, data preservation, and other features.
+
+- At this time, no data you upload or create within TIKE is guaranteed to be preserved.  We recommend periodically backing up essential files.
+
+- TIKE is free to use, and users do not require an AWS account to use TIKE or to access STScI's Public Datasets in AWS.
+
+- Several resources are available to support TIKE usage, and we expect more to be added in the coming months. At this time, sources include this TIKE_content Github repository, a copy of which is provided in each user's home directory.
+
+- Usage is monitored, and access will be restricted as needed in order to provide an acceptable level of service to all users.
 
 
 ## More Information


### PR DESCRIPTION
I made a few minor additions and changes to the markdown files, and I updated the three notebooks under "code/" to now use the TESS Environment by default.