### PR TITLE
Minor updates to tike_content material

### DIFF
--- a/code/cloud_astroquery.ipynb
+++ b/code/cloud_astroquery.ipynb
@@ -171,9 +171,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "TESS Environment",
    "language": "python",
-   "name": "python3"
+   "name": "tess"
   },
   "language_info": {
    "codemirror_mode": {

--- a/code/cloud_astroquery.ipynb
+++ b/code/cloud_astroquery.ipynb
@@ -149,41 +149,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Manifest Files\n",
-    "\n",
-    "Sometimes it is useful to be able to peruse the contents of the directories. S3 does not allow you to do that easily. The public buckets include a manifest. You can directly use the AWS module `boto3` to request the manifest file. \n",
-    "\n",
-    "Here is an example for TESS where it transfers the file to a file called tess-manifest.txt.gz. The manifest file in the bucket is called tess/public/manifest.txt.gz where 'stpubdata' is the name of the bucket. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import boto3\n",
-    "import botocore #botocore is needed to request direct, credential-free access to MAST s3 data\n",
-    "\n",
-    "config = botocore.client.Config(signature_version=botocore.UNSIGNED)\n",
-    "\n",
-    "s3 = boto3.resource('s3',config=config)\n",
-    "bucket = s3.Bucket('stpubdata')\n",
-    "bucket.download_file(\"tess/public/manifest.txt.gz\", \n",
-    "                     \"tess-manifest.txt.gz\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "When you open the file (tess-manifest.txt.gz) it will contain a full listing of the data files available for that mission."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "---"
    ]
   },
@@ -193,7 +158,7 @@
    "source": [
     "author: Susan Mullally\n",
     "\n",
-    "date: 2020-04-24 (updated 2021-08-18)"
+    "date: 2020-04-24 (updated 2021-12-06)"
    ]
   },
   {
@@ -206,9 +171,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "TESS Environment",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "tess"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/content/Introduction.md
+++ b/content/Introduction.md
@@ -15,11 +15,11 @@ or you can use the links below to learn more.
 <img src="../images/icons/school_black_24dp.svg" style="vertical-align: bottom; width:1.5em; margin-right:0.25em;"/> [Example science tutorials](science-examples.md)
 
 
-**Caution!** TIKE computing and storage are limited resources. At this time, no data you upload or create within TIKE is guaranteed to remain for any duration. Files in your home directory (/home/jovyan) will persist on a best-effort basis, but we strongly recommend that you back up any essential code and data to another system.  We encourage users to store large files only sparingly: we will limit the average data volume of user home directories to approximately 25 GB or less, and we will periodically remove excessive data if needed. 
+**Caution!** TIKE computing and storage are limited resources. At this time, no data you upload or create within TIKE is guaranteed to remain for any duration. Files in your home directory (/home/jovyan) will persist on a best-effort basis, but we strongly recommend that you back up any essential code and data to another system.  We encourage users to store large files only sparingly: we will limit the average data volume of user home directories to approximately 25 GB or less, and we will periodically remove excessive data if needed.
 
 **What's New?** See the [News Page](news.md) for recent updates to TIKE.
 
 **Questions?** Please email the [MAST help desk](mailto:archive@stsci.edu) or [open an issue on GitHub](https://github.com/spacetelescope/tike_content). We particularly welcome suggestions for adding additional packages and tutorials.
 
 ---
-*Last Updated: 2021-08-18*
+*Last Updated: 2021-12-07*

--- a/content/extra-software.md
+++ b/content/extra-software.md
@@ -7,6 +7,7 @@ While pre-installation is the preferred method, users may occasionally wish to i
 **Caution:** installing extra software may alter the functionality of your environment. Proceed at your own risk. Fortunately, TIKE creates an isolated environment for each individual user, so you will not be able to harm the platform for others.
 
 
+
 ## Installing an extra Python package
 
 The easiest way to add a Python package to your TIKE environment is to install it using the `pip` terminal command. You can call this command from a notebook cell by prefixing it with the `!` character, for example:
@@ -24,22 +25,22 @@ To upgrade an existing package that is already installed, you will need to add t
 These commands will only work for Python packages that have been published on the [Python Package Index](https://pypi.org). If a package has not been published there, you can install it straight from a git repository as follows:
 
 ```
-!pip install git+https://github.com/astropy/astropy.git 
+!pip install git+https://github.com/astropy/astropy.git
 ```
 
 
 ## Creating a new Python environment
 
-The `pip` command demonstrate above will alter the Python environment that is running your notebook. To avoid altering the default environment, it is often desirable to install packages in a custom environment.
+The `pip` command demonstrate above will alter the Python environment that is running your notebook. To avoid altering the default environment, it is often desirable to install packages in a custom environment.  Furthermore, TIKE provides a pre-specified Python environment that refreshes each time the computing server is restarted. While it is possible to temporarily update the TIKE environments using pip or conda commands during a session, as described above, such changes will not persist after the notebook server is restarted.
 
-You can create a custom Python notebook environment on TIKE by entering the following commands in a terminal (<span style="font-variant:small-caps;">file › new › terminal</span>):
+You can create a custom, persistent Python notebook environment on TIKE by entering the following commands in a terminal (<span style="font-variant:small-caps;">file › new › terminal</span>):
 
 ```
 python -m venv userenv
 source userenv/bin/activate
 ```
 
-In this example, `userenv` is the arbitrary name of the environment. You can choose a different name. 
+In this example, `userenv` is the arbitrary name of the environment. You can choose a different name.
 
 Next, you need to register the new Python environment for use in your instance of TIKE's Jupyter notebook server. This can be done using the `ipykernel` tool as follows:
 
@@ -50,6 +51,15 @@ python -m ipykernel install --user --name=userenv
 
 Having executed these commands, the Jupyter notebook server should automatically recognize the new kernel and offer it as an option.
 
+
+## Creating a new Anaconda environment
+
+ In addition to creating a new persistent Python virtual environment as described above, it is also possible to create a custom Anaconda or Miniconda environment in your TIKE home directory (`/home/jovyan`) by uploading the appropriate installation script into TIKE. To use one of these new environments (e.g. `mycondaenv`) in notebooks, similar to the above, you will need to register it in your instance of TIKE's Jupyter notebook server:
+ ```
+ conda activate mycondaenv
+ pip install ipykernel
+ python -m ipykernel install --user --name=mycondaenv
+ ```
 
 ## Installing extra Linux software
 

--- a/content/news.md
+++ b/content/news.md
@@ -1,5 +1,9 @@
-# News, Updates, and Changes to the TESS Science Platform
+# News, Updates, and Changes to the TIKE Science Platform
 
-- 2021-07-19: Updated for single Tess kernel which omits eleanor due to Tensorflow security vulnerabilities for Tensorflow < 2.
+- 2021-12-15: Initial version of TIKE available for use!
 
-- 2020-04-06: Added News File.  A news.txt file was added to the content directories to document when we make major changes to the platform or the content.  Large changes should also be copied to the News section of Introduction.md.
+- 2021-11-03: Updated TESS kernel to include prototype support for TESS cube cutouts from S3 in astrocut.
+
+- 2021-07-19: Updated for single TESS kernel. Be sure to check that notebooks are using the expected Python kernels.
+
+- 2020-04-06: Added News File.  A news.txt file was added to the content directories to document when we make major changes to the platform or the content.  Large changes should also be copied to Introduction.md.

--- a/content/science-examples-github.md
+++ b/content/science-examples-github.md
@@ -1,0 +1,64 @@
+# Example science tutorials
+
+These tutorials are specific to a particular science case and show how to use the MAST programmatic interface and the AWS science platform to do research. 
+
+## Science with TESS
+
+* [Beginner: Read and Plot A TESS Data Validation Timeseries File](https://spacetelescope.github.io/notebooks/notebooks/MAST/TESS/beginner_how_to_use_dvt/beginner_how_to_use_dvt.html)
+* [Beginner: Read and Display a TESS Full Frame Image](https://spacetelescope.github.io/notebooks/notebooks/MAST/TESS/beginner_how_to_use_ffi/beginner_how_to_use_ffi.html)
+* [Beginner: Read and Plot A TESS Light Curve File](https://spacetelescope.github.io/notebooks/notebooks/MAST/TESS/beginner_how_to_use_lc/beginner_how_to_use_lc.html)
+* [Beginner: Read and Display A TESS Target Pixel File](https://spacetelescope.github.io/notebooks/notebooks/MAST/TESS/beginner_how_to_use_tp/beginner_how_to_use_tp.html)
+* [Beginner: Search The TESS Input Catalog Centered On HD 209458](https://spacetelescope.github.io/notebooks/notebooks/MAST/TESS/beginner_tic_search_hd209458/beginner_tic_search_hd209458.html)
+* [Beginner: A Tour of the Contents of the TESS 2-minute Cadence Data](https://spacetelescope.github.io/notebooks/notebooks/MAST/TESS/beginner_tour_lc_tp/beginner_tour_lc_tp.html)
+* [Beginner: Cutout of the TESS FFIs using Astrocut and Astroquery](https://spacetelescope.github.io/notebooks/notebooks/MAST/TESS/interm_tesscut_astroquery/interm_tesscut_astroquery.html)
+* [Intermediate: Search and Download GI Program Light Curves](https://spacetelescope.github.io/notebooks/notebooks/MAST/TESS/interm_gi_query/interm_gi_query.html)
+* [Intermediate: Create TESS FFI Cutout using Python Requests](https://spacetelescope.github.io/notebooks/notebooks/MAST/TESS/interm_tesscut_requests/interm_tesscut_requests.html)
+
+
+## Science with Kepler & K2
+
+
+### Beginner Notebooks
+
+* [Using Kepler Data to Plot a Light Curve](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/Kepler_Lightcurve/kepler_lightcurve.ipynb)
+* [Plotting Images from Kepler Target Pixel Files](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/Kepler_TPF/kepler_tpf.ipynb)
+* [Read and Plot a Kepler Data Validation Timeseries File](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/Kepler_DVT/Kepler_DVT.ipynb)
+* [Plotting a Catalog over a Kepler Full Frame Image File](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/Kepler_FFI/kepler_ffi.ipynb)
+* [Read and Plot A K2 Light Curve File](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/K2/K2_Lightcurve/K2_Lightcurve.ipynb)
+* [Read and Display A K2 Target Pixel File](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/K2/K2_TPF/K2_TPF.ipynb)
+* [Read and Display a K2 Full Frame Image](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/K2/beginner_how_to_use_ffi/beginner_how_to_use_ffi.ipynb)
+
+
+### Working with Lightkurve
+
+* [Using Kepler Light Curve Products with Lightkurve](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_using_light_curve_products_with_lightkurve/kepler_using_light_curve_products_with_lightkurve.ipynb)
+* [Using Kepler Target Pixel File Products with Lightkurve](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_using_target_pixel_file_products_with_lightkurve/kepler_using_target_pixel_file_products_with_lightkurve.ipynb)
+* [Plotting Kepler Target Pixel File Products with Lightkurve](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_plotting_target_pixel_files/kepler_plotting_target_pixel_files.ipynb)
+* [Searching for Kepler/K2 and TESS Data Products Using Lightkurve](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_searching_for_data_products/kepler_searching_for_data_products.ipynb)
+* [Creating Your Own Light Curves using Custom Aperture Photometry](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_creating_your_own_light_curves/kepler_creating_your_own_light_curves.ipynb)
+* [Combining Multiple Quarters of Kepler Data with Lightkurve](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_combining_multiple_quarters/kepler_combining_multiple_quarters.ipynb)
+* [Interactively Inspecting Target Pixel Files and Light Curves](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_interactively_inspecting_target_pixel_files_and_light_curves/kepler_interactively_inspecting_target_pixel_files_and_light_curves.ipynb)
+
+
+### Understanding Instrumental Noise
+
+* [Instrumental Noise in Kepler and K2 #1: Data Gaps and Quality Flags](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_instrumental_noise_1_data_gaps_and_quality_flags/kepler_instrumental_noise_1_data_gaps_and_quality_flags.ipynb)
+* [Instrumental Noise in Kepler and K2 #2: Spurious Signals and Time Sampling Effects](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_instrumental_noise_2_spurious_signals_and_time_sampling_effects/kepler_instrumental_noise_2_spurious_signals_and_time_sampling_effects.ipynb)
+* [Instrumental Noise in Kepler and K2 #3: Seasonal and Detector Effects](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_instrumental_noise_3_seasonal_and_detector_effects/kepler_instrumental_noise_3_seasonal_and_detector_effects.ipynb)
+* [Instrumental Noise in Kepler and K2 #4: Electronic Noise](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_instrumental_noise_4_electronic_noise/kepler_instrumental_noise_4_electronic_noise.ipynb)
+* [Removing Instrumental Noise from K2 and TESS Light Curves Using Pixel Level Decorrelation (PLD)](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/K2/k2_removing_instrumental_noise_using_pld/k2_removing_instrumental_noise_using_pld.ipynb)
+
+
+### Identifying Periodic Signals
+
+* [Identifying Transiting Planet Signals in a Kepler Light Curve](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_identifying_transiting_planet_signals/kepler_identifying_transiting_planet_signals.ipynb)
+* [Measuring and Removing a Rotation Period Signal from a Kepler Light Curve](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_measuring_a_rotation_period/kepler_measuring_a_rotation_period.ipynb)
+* [Visualizing Periodic Signals Using a River Plot](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_visualizing_periodic_signals_using_a_river_plot/kepler_visualizing_periodic_signals_using_a_river_plot.ipynb)
+* [Verifying the Location of a Signal in Kepler Pixel Data](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_verifying_the_location_of_a_signal/kepler_verifying_the_location_of_a_signal.ipynb)
+
+
+### Periodograms & Asteroseismology
+
+* [Creating Periodograms and Identifying Significant Peaks](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_creating_periodograms/kepler_creating_periodograms.ipynb)
+* [How to Understand and Manipulate the Periodogram of an Oscillating Star](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_how_to_understand_and_manipulate_the_periodogram_of_an_oscillating_star/kepler_how_to_understand_and_manipulate_the_periodogram_of_an_oscillating_star.ipynb)
+* [How to Estimate a Star's Mass and Radius Using Asteroseismology](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_how_to_estimate_a_stars_mass_and_radius_using_asteroseismology/kepler_how_to_estimate_a_stars_mass_and_radius_using_asteroseismology.ipynb)

--- a/content/science-examples.md
+++ b/content/science-examples.md
@@ -1,18 +1,20 @@
 # Example science tutorials
 
-These tutorials are specific to a particular science case and show how to use the MAST programmatic interface and the AWS science platform to do research. 
+These tutorials are specific to a particular science case and show how to use the MAST programmatic interface and the JupyterHub science platform to do research. The links on this page may only work within the TIKE platform, but you can find external links to the notebooks in GitHub here:  [Example science tutorials (GitHub)](science-examples-github.md).
+
+**NOTE!**  In order for these notebooks to access the expected packages in TIKE, you may have to switch to the TESS kernel after you open them.  You can do this either by using the dropdown menu at the upper right of the notebook, or in the top JupyterLab menu (Kernel › Change Kernel...).
 
 ## Science with TESS
 
-* [Beginner: Read and Plot A TESS Data Validation Timeseries File](https://spacetelescope.github.io/notebooks/notebooks/MAST/TESS/beginner_how_to_use_dvt/beginner_how_to_use_dvt.html)
-* [Beginner: Read and Display a TESS Full Frame Image](https://spacetelescope.github.io/notebooks/notebooks/MAST/TESS/beginner_how_to_use_ffi/beginner_how_to_use_ffi.html)
-* [Beginner: Read and Plot A TESS Light Curve File](https://spacetelescope.github.io/notebooks/notebooks/MAST/TESS/beginner_how_to_use_lc/beginner_how_to_use_lc.html)
-* [Beginner: Read and Display A TESS Target Pixel File](https://spacetelescope.github.io/notebooks/notebooks/MAST/TESS/beginner_how_to_use_tp/beginner_how_to_use_tp.html)
-* [Beginner: Search The TESS Input Catalog Centered On HD 209458](https://spacetelescope.github.io/notebooks/notebooks/MAST/TESS/beginner_tic_search_hd209458/beginner_tic_search_hd209458.html)
-* [Beginner: A Tour of the Contents of the TESS 2-minute Cadence Data](https://spacetelescope.github.io/notebooks/notebooks/MAST/TESS/beginner_tour_lc_tp/beginner_tour_lc_tp.html)
-* [Beginner: Cutout of the TESS FFIs using Astrocut and Astroquery](https://spacetelescope.github.io/notebooks/notebooks/MAST/TESS/interm_tesscut_astroquery/interm_tesscut_astroquery.html)
-* [Intermediate: Search and Download GI Program Light Curves](https://spacetelescope.github.io/notebooks/notebooks/MAST/TESS/interm_gi_query/interm_gi_query.html)
-* [Intermediate: Create TESS FFI Cutout using Python Requests](https://spacetelescope.github.io/notebooks/notebooks/MAST/TESS/interm_tesscut_requests/interm_tesscut_requests.html)
+* [Beginner: Read and Plot A TESS Data Validation Timeseries File](../../spacetelescope-notebooks/notebooks/MAST/TESS/beginner_how_to_use_dvt/beginner_how_to_use_dvt.ipynb)
+* [Beginner: Read and Display a TESS Full Frame Image](../../spacetelescope-notebooks/notebooks/MAST/TESS/beginner_how_to_use_ffi/beginner_how_to_use_ffi.ipynb)
+* [Beginner: Read and Plot A TESS Light Curve File](../../spacetelescope-notebooks/notebooks/MAST/TESS/beginner_how_to_use_lc/beginner_how_to_use_lc.ipynb)
+* [Beginner: Read and Display A TESS Target Pixel File](../../spacetelescope-notebooks/notebooks/MAST/TESS/beginner_how_to_use_tp/beginner_how_to_use_tp.ipynb)
+* [Beginner: Search The TESS Input Catalog Centered On HD 209458](../../spacetelescope-notebooks/notebooks/MAST/TESS/beginner_tic_search_hd209458/beginner_tic_search_hd209458.ipynb)
+* [Beginner: A Tour of the Contents of the TESS 2-minute Cadence Data](../../spacetelescope-notebooks/notebooks/MAST/TESS/beginner_tour_lc_tp/beginner_tour_lc_tp.ipynb)
+* [Beginner: Cutout of the TESS FFIs using Astrocut and Astroquery](../../spacetelescope-notebooks/notebooks/MAST/TESS/interm_tesscut_astroquery/interm_tesscut_astroquery.ipynb)
+* [Intermediate: Search and Download GI Program Light Curves](../../spacetelescope-notebooks/notebooks/MAST/TESS/interm_gi_query/interm_gi_query.ipynb)
+* [Intermediate: Create TESS FFI Cutout using Python Requests](../../spacetelescope-notebooks/notebooks/MAST/TESS/interm_tesscut_requests/interm_tesscut_requests.ipynb)
 
 
 ## Science with Kepler & K2
@@ -20,45 +22,45 @@ These tutorials are specific to a particular science case and show how to use th
 
 ### Beginner Notebooks
 
-* [Using Kepler Data to Plot a Light Curve](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/Kepler_Lightcurve/kepler_lightcurve.ipynb)
-* [Plotting Images from Kepler Target Pixel Files](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/Kepler_TPF/kepler_tpf.ipynb)
-* [Read and Plot a Kepler Data Validation Timeseries File](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/Kepler_DVT/Kepler_DVT.ipynb)
-* [Plotting a Catalog over a Kepler Full Frame Image File](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/Kepler_FFI/kepler_ffi.ipynb)
-* [Read and Plot A K2 Light Curve File](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/K2/K2_Lightcurve/K2_Lightcurve.ipynb)
-* [Read and Display A K2 Target Pixel File](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/K2/K2_TPF/K2_TPF.ipynb)
-* [Read and Display a K2 Full Frame Image](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/K2/beginner_how_to_use_ffi/beginner_how_to_use_ffi.ipynb)
+* [Using Kepler Data to Plot a Light Curve](../../spacetelescope-notebooks/notebooks/MAST/Kepler/Kepler_Lightcurve/kepler_lightcurve.ipynb)
+* [Plotting Images from Kepler Target Pixel Files](../../spacetelescope-notebooks/notebooks/MAST/Kepler/Kepler_TPF/kepler_tpf.ipynb)
+* [Read and Plot a Kepler Data Validation Timeseries File](../../spacetelescope-notebooks/notebooks/MAST/Kepler/Kepler_DVT/Kepler_DVT.ipynb)
+* [Plotting a Catalog over a Kepler Full Frame Image File](../../spacetelescope-notebooks/notebooks/MAST/Kepler/Kepler_FFI/kepler_ffi.ipynb)
+* [Read and Plot A K2 Light Curve File](../../spacetelescope-notebooks/notebooks/MAST/K2/K2_Lightcurve/K2_Lightcurve.ipynb)
+* [Read and Display A K2 Target Pixel File](../../spacetelescope-notebooks/notebooks/MAST/K2/K2_TPF/K2_TPF.ipynb)
+* [Read and Display a K2 Full Frame Image](../../spacetelescope-notebooks/notebooks/MAST/K2/beginner_how_to_use_ffi/beginner_how_to_use_ffi.ipynb)
 
 
 ### Working with Lightkurve
 
-* [Using Kepler Light Curve Products with Lightkurve](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_using_light_curve_products_with_lightkurve/kepler_using_light_curve_products_with_lightkurve.ipynb)
-* [Using Kepler Target Pixel File Products with Lightkurve](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_using_target_pixel_file_products_with_lightkurve/kepler_using_target_pixel_file_products_with_lightkurve.ipynb)
-* [Plotting Kepler Target Pixel File Products with Lightkurve](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_plotting_target_pixel_files/kepler_plotting_target_pixel_files.ipynb)
-* [Searching for Kepler/K2 and TESS Data Products Using Lightkurve](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_searching_for_data_products/kepler_searching_for_data_products.ipynb)
-* [Creating Your Own Light Curves using Custom Aperture Photometry](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_creating_your_own_light_curves/kepler_creating_your_own_light_curves.ipynb)
-* [Combining Multiple Quarters of Kepler Data with Lightkurve](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_combining_multiple_quarters/kepler_combining_multiple_quarters.ipynb)
-* [Interactively Inspecting Target Pixel Files and Light Curves](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_interactively_inspecting_target_pixel_files_and_light_curves/kepler_interactively_inspecting_target_pixel_files_and_light_curves.ipynb)
+* [Using Kepler Light Curve Products with Lightkurve](../../spacetelescope-notebooks/notebooks/MAST/Kepler/kepler_using_light_curve_products_with_lightkurve/kepler_using_light_curve_products_with_lightkurve.ipynb)
+* [Using Kepler Target Pixel File Products with Lightkurve](../../spacetelescope-notebooks/notebooks/MAST/Kepler/kepler_using_target_pixel_file_products_with_lightkurve/kepler_using_target_pixel_file_products_with_lightkurve.ipynb)
+* [Plotting Kepler Target Pixel File Products with Lightkurve](../../spacetelescope-notebooks/notebooks/MAST/Kepler/kepler_plotting_target_pixel_files/kepler_plotting_target_pixel_files.ipynb)
+* [Searching for Kepler/K2 and TESS Data Products Using Lightkurve](../../spacetelescope-notebooks/notebooks/MAST/Kepler/kepler_searching_for_data_products/kepler_searching_for_data_products.ipynb)
+* [Creating Your Own Light Curves using Custom Aperture Photometry](../../spacetelescope-notebooks/notebooks/MAST/Kepler/kepler_creating_your_own_light_curves/kepler_creating_your_own_light_curves.ipynb)
+* [Combining Multiple Quarters of Kepler Data with Lightkurve](../../spacetelescope-notebooks/notebooks/MAST/Kepler/kepler_combining_multiple_quarters/kepler_combining_multiple_quarters.ipynb)
+* [Interactively Inspecting Target Pixel Files and Light Curves](../../spacetelescope-notebooks/notebooks/MAST/Kepler/kepler_interactively_inspecting_target_pixel_files_and_light_curves/kepler_interactively_inspecting_target_pixel_files_and_light_curves.ipynb)
 
 
 ### Understanding Instrumental Noise
 
-* [Instrumental Noise in Kepler and K2 #1: Data Gaps and Quality Flags](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_instrumental_noise_1_data_gaps_and_quality_flags/kepler_instrumental_noise_1_data_gaps_and_quality_flags.ipynb)
-* [Instrumental Noise in Kepler and K2 #2: Spurious Signals and Time Sampling Effects](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_instrumental_noise_2_spurious_signals_and_time_sampling_effects/kepler_instrumental_noise_2_spurious_signals_and_time_sampling_effects.ipynb)
-* [Instrumental Noise in Kepler and K2 #3: Seasonal and Detector Effects](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_instrumental_noise_3_seasonal_and_detector_effects/kepler_instrumental_noise_3_seasonal_and_detector_effects.ipynb)
-* [Instrumental Noise in Kepler and K2 #4: Electronic Noise](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_instrumental_noise_4_electronic_noise/kepler_instrumental_noise_4_electronic_noise.ipynb)
-* [Removing Instrumental Noise from K2 and TESS Light Curves Using Pixel Level Decorrelation (PLD)](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/K2/k2_removing_instrumental_noise_using_pld/k2_removing_instrumental_noise_using_pld.ipynb)
+* [Instrumental Noise in Kepler and K2 #1: Data Gaps and Quality Flags](../../spacetelescope-notebooks/notebooks/MAST/Kepler/kepler_instrumental_noise_1_data_gaps_and_quality_flags/kepler_instrumental_noise_1_data_gaps_and_quality_flags.ipynb)
+* [Instrumental Noise in Kepler and K2 #2: Spurious Signals and Time Sampling Effects](../../spacetelescope-notebooks/notebooks/MAST/Kepler/kepler_instrumental_noise_2_spurious_signals_and_time_sampling_effects/kepler_instrumental_noise_2_spurious_signals_and_time_sampling_effects.ipynb)
+* [Instrumental Noise in Kepler and K2 #3: Seasonal and Detector Effects](../../spacetelescope-notebooks/notebooks/MAST/Kepler/kepler_instrumental_noise_3_seasonal_and_detector_effects/kepler_instrumental_noise_3_seasonal_and_detector_effects.ipynb)
+* [Instrumental Noise in Kepler and K2 #4: Electronic Noise](../../spacetelescope-notebooks/notebooks/MAST/Kepler/kepler_instrumental_noise_4_electronic_noise/kepler_instrumental_noise_4_electronic_noise.ipynb)
+* [Removing Instrumental Noise from K2 and TESS Light Curves Using Pixel Level Decorrelation (PLD)](../../spacetelescope-notebooks/notebooks/MAST/K2/k2_removing_instrumental_noise_using_pld/k2_removing_instrumental_noise_using_pld.ipynb)
 
 
 ### Identifying Periodic Signals
 
-* [Identifying Transiting Planet Signals in a Kepler Light Curve](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_identifying_transiting_planet_signals/kepler_identifying_transiting_planet_signals.ipynb)
-* [Measuring and Removing a Rotation Period Signal from a Kepler Light Curve](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_measuring_a_rotation_period/kepler_measuring_a_rotation_period.ipynb)
-* [Visualizing Periodic Signals Using a River Plot](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_visualizing_periodic_signals_using_a_river_plot/kepler_visualizing_periodic_signals_using_a_river_plot.ipynb)
-* [Verifying the Location of a Signal in Kepler Pixel Data](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_verifying_the_location_of_a_signal/kepler_verifying_the_location_of_a_signal.ipynb)
+* [Identifying Transiting Planet Signals in a Kepler Light Curve](../../spacetelescope-notebooks/notebooks/MAST/Kepler/kepler_identifying_transiting_planet_signals/kepler_identifying_transiting_planet_signals.ipynb)
+* [Measuring and Removing a Rotation Period Signal from a Kepler Light Curve](../../spacetelescope-notebooks/notebooks/MAST/Kepler/kepler_measuring_a_rotation_period/kepler_measuring_a_rotation_period.ipynb)
+* [Visualizing Periodic Signals Using a River Plot](../../spacetelescope-notebooks/notebooks/MAST/Kepler/kepler_visualizing_periodic_signals_using_a_river_plot/kepler_visualizing_periodic_signals_using_a_river_plot.ipynb)
+* [Verifying the Location of a Signal in Kepler Pixel Data](../../spacetelescope-notebooks/notebooks/MAST/Kepler/kepler_verifying_the_location_of_a_signal/kepler_verifying_the_location_of_a_signal.ipynb)
 
 
 ### Periodograms & Asteroseismology
 
-* [Creating Periodograms and Identifying Significant Peaks](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_creating_periodograms/kepler_creating_periodograms.ipynb)
-* [How to Understand and Manipulate the Periodogram of an Oscillating Star](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_how_to_understand_and_manipulate_the_periodogram_of_an_oscillating_star/kepler_how_to_understand_and_manipulate_the_periodogram_of_an_oscillating_star.ipynb)
-* [How to Estimate a Star's Mass and Radius Using Asteroseismology](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/kepler_how_to_estimate_a_stars_mass_and_radius_using_asteroseismology/kepler_how_to_estimate_a_stars_mass_and_radius_using_asteroseismology.ipynb)
+* [Creating Periodograms and Identifying Significant Peaks](../../spacetelescope-notebooks/notebooks/MAST/Kepler/kepler_creating_periodograms/kepler_creating_periodograms.ipynb)
+* [How to Understand and Manipulate the Periodogram of an Oscillating Star](../../spacetelescope-notebooks/notebooks/MAST/Kepler/kepler_how_to_understand_and_manipulate_the_periodogram_of_an_oscillating_star/kepler_how_to_understand_and_manipulate_the_periodogram_of_an_oscillating_star.ipynb)
+* [How to Estimate a Star's Mass and Radius Using Asteroseismology](../../spacetelescope-notebooks/notebooks/MAST/Kepler/kepler_how_to_estimate_a_stars_mass_and_radius_using_asteroseismology/kepler_how_to_estimate_a_stars_mass_and_radius_using_asteroseismology.ipynb)


### PR DESCRIPTION
Minor updates to tike_content material, including the following:

- delete "manifest file" section from code/cloud_astroquery.ipynb, until these files can be updated again.
- update "content/news.md", "content/Introduction.md" with minor changes, dates, etc
- Update "content/extra-software.md" to mention that changes to base TIKE env are temporary, and add section on possibility of using a custom persistent conda environment.
- Copied "content/science-examples.md" to "content/science-examples-github.md".  Changed links in "content/science-examples.md" so that they open the notebooks themselves running within TIKE.  Added text to guide users to this change.