### PR TITLE
modify method call to work with new interface for download_cutouts

### DIFF
--- a/code/test_notebooks/packages_priority2.ipynb
+++ b/code/test_notebooks/packages_priority2.ipynb
@@ -246,7 +246,7 @@
     "target = '{0}, {1}'.format(ra, dec)\n",
     "x = y = 11\n",
     "cutout_coords = SkyCoord(ra, dec, unit=\"deg\")\n",
-    "table = Tesscut.download_cutouts(cutout_coords, size=x)\n",
+    "table = Tesscut.download_cutouts(coordinates=cutout_coords, size=x)\n",
     "files = table['Local Path']\n",
     "filename = files[0]\n",
     "tpf = k2flix.TargetPixelFile(filename)\n",


### PR DESCRIPTION
We are working on an update to the TIKE science platform but one method in our test notebook is out of date - this is the update to that notebook - it requires a named parameter instead of a positional one