### PR TITLE
updates to zooniverse

### DIFF
--- a/content/notebooks/zooniverse_view_lightcurve/zooniverse_view_lightcurve.ipynb
+++ b/content/notebooks/zooniverse_view_lightcurve/zooniverse_view_lightcurve.ipynb
@@ -51,22 +51,27 @@
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import matplotlib as mpl\n",
+    "import s3fs\n",
     "\n",
     "mpl.rcParams['figure.dpi'] = 600\n",
     "Observations.enable_cloud_dataset()\n",
+    "fs = s3fs.S3FileSystem(anon=True)\n",
     "\n",
     "obs = Observations.query_criteria(target_name=tic_id, obs_collection=\"TESS\", sequence_number=sector)\n",
     "\n",
     "if len(obs)==0:\n",
     "    raise UserWarning(\"No matching observations. Are you certain the target was observed in this sector?\")\n",
     "\n",
-    "files = Observations.get_product_list(obs)\n",
-    "fits_file = Observations.download_products(files, description=\"Light curves\")\n",
+    "prod = Observations.get_product_list(obs)\n",
+    "filtered = Observations.filter_products(prod, productSubGroupDescription=\"LC\")\n",
+    "cloud_uri = Observations.get_cloud_uris(filtered)[0]\n",
     "\n",
-    "with fits.open(fits_file['Local Path'][0], mode=\"readonly\") as hdulist:\n",
-    "    tess_bjds = hdulist[1].data['TIME']\n",
-    "    sap_fluxes = hdulist[1].data['SAP_FLUX']\n",
-    "    pdcsap_fluxes = hdulist[1].data['PDCSAP_FLUX']\n",
+    "with fs.open(cloud_uri, 'rb') as f:\n",
+    "    # Now actually read in the FITS file \n",
+    "    with fits.open(f, 'readonly') as hdulist:\n",
+    "        tess_bjds = hdulist[1].data['TIME']\n",
+    "        sap_fluxes = hdulist[1].data['SAP_FLUX']\n",
+    "        pdcsap_fluxes = hdulist[1].data['PDCSAP_FLUX']\n",
     "    \n",
     "fig, ax = plt.subplots(figsize=(10, 4))\n",
     "ax.scatter(tess_bjds, pdcsap_fluxes, s=1, color='r')\n",
@@ -136,6 +141,7 @@
     "* `astroquery.mast` : this makes it easy to query MAST for TESS data\n",
     "* `matplotlib` : we only do this import so that we can change the DPI below\n",
     "* `matplotlib.pyplot` : this gives us the tools for making pleasant-looking plots\n",
+    "* `s3.fs`: this lets us access the data stored in our cloud\n",
     "\n",
     "Below the imports, we make some minor adjustments to the DPI, to increase the resolution of our graphs, and \"enable cloud datasets\". This second piece is important: TIKE (the platform you're currently on) is hosted in the cloud. Reading data from our cloud archive is therefore much faster than trying to read from our servers in Baltimore."
    ]
@@ -154,6 +160,7 @@
     "\n",
     "import matplotlib as mpl\n",
     "import matplotlib.pyplot as plt\n",
+    "import s3fs\n",
     "\n",
     "mpl.rcParams['figure.dpi'] = 600\n",
     "Observations.enable_cloud_dataset()"
@@ -237,7 +244,12 @@
    },
    "outputs": [],
    "source": [
-    "fits_file = Observations.download_products(files, description=\"Light curves\")"
+    "# get the product list\n",
+    "prod = Observations.get_product_list(obs)\n",
+    "\n",
+    "# keep only the light curves\n",
+    "filtered = Observations.filter_products(prod, productSubGroupDescription=\"LC\")\n",
+    "cloud_uri = Observations.get_cloud_uris(filtered)[0]"
    ]
   },
   {
@@ -252,14 +264,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aa244de7-38f1-45ec-9668-8b67261a61d3",
-   "metadata": {
-    "tags": []
-   },
+   "id": "ab67757b-bfdd-452c-9ebb-5679c3bf63c5",
+   "metadata": {},
    "outputs": [],
    "source": [
-    "file_path = fits_file['Local Path'][0]\n",
-    "fits.info(file_path)"
+    "with fs.open(cloud_uri, 'rb') as f:\n",
+    "    fits.info(f)"
    ]
   },
   {
@@ -282,9 +292,10 @@
    "outputs": [],
    "source": [
     "# Warning! This prints out a lot of text\n",
-    "with fits.open(file_path, mode=\"readonly\") as hdulist:\n",
-    "    header1 = hdulist[1].header\n",
-    "    print(repr(header1))"
+    "with fs.open(cloud_uri, 'rb') as f:\n",
+    "    with fits.open(f, mode=\"readonly\") as hdulist:\n",
+    "        header1 = hdulist[1].header\n",
+    "        print(repr(header1))"
    ]
   },
   {
@@ -306,10 +317,11 @@
    },
    "outputs": [],
    "source": [
-    "with fits.open(file_path, mode=\"readonly\") as hdulist:\n",
-    "    tess_bjds = hdulist[1].data['TIME']\n",
-    "    sap_fluxes = hdulist[1].data['SAP_FLUX']\n",
-    "    pdcsap_fluxes = hdulist[1].data['PDCSAP_FLUX']"
+    "with fs.open(cloud_uri, 'rb') as f:\n",
+    "    with fits.open(f, mode=\"readonly\") as hdulist:\n",
+    "        tess_bjds = hdulist[1].data['TIME']\n",
+    "        sap_fluxes = hdulist[1].data['SAP_FLUX']\n",
+    "        pdcsap_fluxes = hdulist[1].data['PDCSAP_FLUX']"
    ]
   },
   {
@@ -398,7 +410,7 @@
     "\n",
     "**Author:** Thomas Dutkiewicz <br>\n",
     "**Keywords:** TIKE, AWS Cloud, Light curves <br>\n",
-    "**Last Updated:** May 2023 <br>\n",
+    "**Last Updated:** Apr 2024 <br>\n",
     "***\n",
     "[Top of Page](#top)\n",
     "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "
@@ -421,7 +433,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- update to use cloud access (avoid downloading files to TIKE)
- exclude DVT files (specifically, only include the LC files)