### PR TITLE
add 2025.07 beta release

### DIFF
--- a/code/image-builds/tike-2025-07-beta.yaml
+++ b/code/image-builds/tike-2025-07-beta.yaml
@@ -1,0 +1,34 @@
+# Image header information
+image_spec_header:
+  image_name: TIKE 2025.07-beta
+  description: |
+    This is a beta test of the latest TIKE packages. Use at your own risk!
+  valid_on: 2025-07-02
+  expires_on: 2025-10-02
+  python_version: 3.11
+  nb_repo: https://github.com/spacetelescope/tike_content
+  root_nb_directory: content/notebooks/
+# these are the useful tike_content notebooks
+selected_notebooks:
+  - include_subdirs:
+      - data-access/
+      - lcviz-tutorial/
+      - tglc/
+      - zooniverse_view_lightcurve/
+  # -------------------------------------------------
+  # note: the below notebooks are included as a test.
+  # they should not be considered a useful subset
+  # of mast_notebooks for future releases
+  # -------------------------------------------------
+  # include TESS notebooks
+  - nb_repo: https://github.com/spacetelescope/mast_notebooks
+    root_nb_directory: notebooks/tess
+    include_subdirs:
+      - beginner_how_to_use_lc
+      - beginner_tour_lc_tp
+  # include Kepler notebooks
+  - nb_repo: https://github.com/spacetelescope/mast_notebooks
+    root_nb_directory: notebooks/kepler
+    include_subdirs:
+      - identifying_transiting_planet_signals
+      - instrumental_noise_4_electronic_noise

--- a/content/Introduction.md
+++ b/content/Introduction.md
@@ -22,6 +22,3 @@ or you can use the links below to learn more.
 **What's New?** See the [News Page](../markdown/news.md) for recent updates to TIKE.
 
 **Questions?** Please email the [MAST help desk](mailto:archive@stsci.edu) or [open an issue on GitHub](https://github.com/spacetelescope/tike_content). We particularly welcome suggestions for adding additional packages and tutorials.
-
----
-*Last Updated: 2023-04-11*

--- a/content/notebooks/data-access/data-access.ipynb
+++ b/content/notebooks/data-access/data-access.ipynb
@@ -67,8 +67,7 @@
     "- `numpy` to automatically set brightness limits in the plot\n",
     "\n",
     "To access the cloud data, we need\n",
-    "- `astroquery.mast` to search for and select data\n",
-    "- `s3fs` to access cloud files as though they were local"
+    "- `astroquery.mast` to search for and select data"
    ]
   },
   {
@@ -79,7 +78,6 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "import s3fs\n",
     "\n",
     "from astropy.io import fits\n",
     "from astroquery.mast import Observations"
@@ -134,7 +132,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This particular product is a combined, [\"drizzled\" FITS file](https://hst-docs.stsci.edu/drizzpac/chapter-3-description-of-the-drizzle-algorithm/3-2-drizzle-concept). Without bogging down this Notebook with technical details, drizzled images are generally better-resolved. This specific drizzled image combines data from four Hubble instruments, and thus will make a particularly nice looking plot.\n",
+    "This particular product is a combined, [\"drizzled\" FITS file](https://hst-docs.stsci.edu/drizzpac/chapter-3-description-of-the-drizzle-algorithm/3-2-drizzle-concept). Without bogging down this notebook in technical details, drizzled images are generally better-resolved. This specific drizzled image combines data from four Hubble instruments, and thus will make a particularly nice looking plot.\n",
     "\n",
     "Now that we've identified a file of interest, we need to locate its cloud URI: where the file is located on the S3 server. This is straightforward with the `get_cloud_uris` function, which allows us to pass a table of products."
    ]
@@ -170,22 +168,6 @@
    "metadata": {},
    "source": [
     "## Loading files directly into memory\n",
-    "Here, we'll use `s3fs` so that Python can properly access data stored in AWS. Note that we must set `anon=True` to access the files."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fs = s3fs.S3FileSystem(anon=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Whether opening a file on the cloud, or on your local machine, it's best practice to close the file once you're done using it. This is most easily done using Python's `with/open` syntax, as we'll do below.\n",
     "\n",
     "**Note:** Code in the `with` statement should only be used to extract data from the file. Relatively slow computations and plot generation should go outside of this statement so that the file can close in a timely manner."
@@ -197,19 +179,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Open the file in AWS: 'F' is the S3 file\n",
-    "with fs.open(c_uri, 'rb') as f:\n",
-    "    # Now actually read in the FITS file \n",
-    "    with fits.open(f, 'readonly') as HDUlist:\n",
-    "        HDUlist.info()\n",
-    "        sci = HDUlist[1].data"
+    "# instead of passing a local file path,\n",
+    "# pass the cloud URI into fits.open()\n",
+    "with fits.open(c_uri, fsspec_kwargs={\"anon\": True}) as hdulist:\n",
+    "    hdulist.info()\n",
+    "    sci = hdulist[1].data"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We've printed out some information about the file, and read the data from HDU 1 into a variable called `sci`. We can now use `sci` to create plots or images."
+    "We've printed out some information about the file, and read the data from `HDU1` into a variable called `sci`. We can now use `sci` to create plots or images."
    ]
   },
   {
@@ -232,7 +213,7 @@
    "source": [
     "This is a neat view of (a part of) the [Horsehead Nebula](https://hubblesite.org/contents/media/images/2013/12/3165-Image.html).\n",
     "\n",
-    "Although this is a reduced, minimum viable example, it still demonstrates that reading data from the cloud is straightforward. With an extra line or two of code, users have access to Terabytes of data, no download required. This is particularly useful for users with slow internet connections, limited storage, or without a personal computer."
+    "Although this is an artificial example, it still demonstrates that reading data from the cloud is straightforward. With an extra line or two of code, users have access to terabytes of data, no downloads required. This is particularly useful for users with slow internet connections, limited storage, or without a personal computer."
    ]
   },
   {
@@ -241,11 +222,11 @@
    "source": [
     "## Bonus: Other methods, Notes, and Caveats\n",
     "\n",
-    "This section is of limited value to the average user looking to analyze astronomical data. Here, we document additional ways to access cloud data that may be of interest to developers or those curious in our cloud infrastructure.\n",
+    "This section is of limited value to the average user looking to analyze astronomical data. Here, we document additional ways to access cloud data that may be of interest to developers or those curious about our cloud infrastructure.\n",
     "\n",
     "### AWS command-line interface\n",
     "\n",
-    "Since all of the cloud files are available to you as if they were local, it is possible to browse through them. This is not a very efficient way to find Observations, but the AWS command-line interface does permit exploration within Jupyter Notebooks (by prefixing the command with `!`) and from a Terminal window (file › new › terminal).\n",
+    "Since all of the cloud files are available to you as if they were local, it is possible to browse through them. This is not a very efficient way to find observations, but the AWS command-line interface does permit exploration within Jupyter Notebooks (by prefixing the command with `!`) and from a Terminal window (file › new › terminal).\n",
     "\n",
     "For example, we can list the contents of the TESS data held in the public MAST S3 bucket:"
    ]
@@ -268,10 +249,7 @@
     "* `mast/` contains the TESS \"cubes\": [stacked FFI images](https://spacetelescope.github.io/mast_notebooks/notebooks/astrocut/making_tess_cubes_and_cutouts/making_tess_cubes_and_cutouts.html) that allow you to easily generate cutouts\n",
     "* `pixel_list` contains an incomplete list of targets and their associated pixels\n",
     "* `staged_cutouts/` is particularly unhelpful; it contains TESS cutouts requested by users. Filenames are randomly generated, so you will not find anything interesting by browsing.\n",
-    "* `tid/` contains all of SPOC-derived TPFs and LCs, sorted by [TESS filename convention](https://archive.stsci.edu/missions-and-data/tess/data-products)\n",
-    "\n",
-    "### Integrated methods\n",
-    "Since cloud data is a relatively new tool, not every packages takes full advantage of TIKE's proximity to cloud data. The ever popular `lightkurve`, for example, will download and cache any files you use while on TIKE. This is slower than the method outlined above and clogs up your storage over time. Work is ongoing to change this behavior, but it make take some time before your favorite package is fully cloud-compatible."
+    "* `tid/` contains all of SPOC-derived TPFs and LCs, sorted by [TESS filename convention](https://archive.stsci.edu/missions-and-data/tess/data-products)"
    ]
   },
   {
@@ -294,12 +272,16 @@
     "If you have comments or questions on this notebook, please contact us through the Archive Help Desk e-mail at archive@stsci.edu. If you spot any errors, open an issue on the [tike_content repository](https://github.com/spacetelescope/tike_content).\n",
     "\n",
     "**Author:** Thomas Dutkiewicz <br>\n",
-    "**Keyword(s):** TIKE, AWS, Cloud <br>\n",
-    "**Last Updated:** Dec 2023 <br>\n",
+    "**Keywords:** TIKE, AWS, Cloud <br>\n",
     "\n",
     "[Top of Page](#top)\n",
     "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {

--- a/content/notebooks/data-access/requirements.txt
+++ b/content/notebooks/data-access/requirements.txt
@@ -1,0 +1,4 @@
+astropy >= 7.0.0
+astroquery >= 0.4.10
+numpy >= 2
+matplotlib >= 3.9

--- a/content/notebooks/lcviz-tutorial/lcviz_tutorial.ipynb
+++ b/content/notebooks/lcviz-tutorial/lcviz_tutorial.ipynb
@@ -33,10 +33,6 @@
    },
    "source": [
     "## Imports\n",
-    "\n",
-    "- *s3fs* used to access cloud files as though they were local\n",
-    "- *astropy.units* used to define quantities with units attached\n",
-    "- *astropy.time Time* used to define the epoch for the ephemeris of the planet\n",
     "- *astroquery.mast* used to search for and select data\n",
     "- *lightkurve* for reading the light curve file\n",
     "- *lcviz* for plotting and analyzing data"
@@ -52,10 +48,6 @@
    },
    "outputs": [],
    "source": [
-    "import s3fs\n",
-    "\n",
-    "import astropy.units as u\n",
-    "from astropy.time import Time\n",
     "from astroquery.mast import Observations\n",
     "import lightkurve\n",
     "\n",

--- a/content/notebooks/lcviz-tutorial/requirements.txt
+++ b/content/notebooks/lcviz-tutorial/requirements.txt
@@ -1,0 +1,3 @@
+astroquery >= 0.4.10
+lightkurve >= 2.5.1
+lcviz >= 1.1

--- a/content/notebooks/tglc/requirements.txt
+++ b/content/notebooks/tglc/requirements.txt
@@ -1,0 +1,5 @@
+astroquery >= 0.4.10
+lightkurve >= 2.5.1
+lcviz >= 1.1
+matplotlib >= 3.9
+numpy >= 2

--- a/content/notebooks/zooniverse_view_lightcurve/requirements.txt
+++ b/content/notebooks/zooniverse_view_lightcurve/requirements.txt
@@ -1,0 +1,3 @@
+astropy >= 7.0.0
+astroquery >= 0.4.10
+matplotlib >= 3.9

--- a/content/notebooks/zooniverse_view_lightcurve/zooniverse_view_lightcurve.ipynb
+++ b/content/notebooks/zooniverse_view_lightcurve/zooniverse_view_lightcurve.ipynb
@@ -55,7 +55,6 @@
     "\n",
     "mpl.rcParams['figure.dpi'] = 600\n",
     "Observations.enable_cloud_dataset()\n",
-    "fs = s3fs.S3FileSystem(anon=True)\n",
     "\n",
     "obs = Observations.query_criteria(target_name=tic_id, obs_collection=\"TESS\", sequence_number=sector)\n",
     "\n",
@@ -66,12 +65,11 @@
     "filtered = Observations.filter_products(prod, productSubGroupDescription=\"LC\")\n",
     "cloud_uri = Observations.get_cloud_uris(filtered)[0]\n",
     "\n",
-    "with fs.open(cloud_uri, 'rb') as f:\n",
-    "    # Now actually read in the FITS file \n",
-    "    with fits.open(f, 'readonly') as hdulist:\n",
-    "        tess_bjds = hdulist[1].data['TIME']\n",
-    "        sap_fluxes = hdulist[1].data['SAP_FLUX']\n",
-    "        pdcsap_fluxes = hdulist[1].data['PDCSAP_FLUX']\n",
+    "# open the fits file\n",
+    "with fits.open(cloud_uri, fsspec_kwargs={\"anon\": True}) as hdulist:\n",
+    "    tess_bjds = hdulist[1].data['TIME']\n",
+    "    sap_fluxes = hdulist[1].data['SAP_FLUX']\n",
+    "    pdcsap_fluxes = hdulist[1].data['PDCSAP_FLUX']\n",
     "    \n",
     "fig, ax = plt.subplots(figsize=(10, 4))\n",
     "ax.scatter(tess_bjds, pdcsap_fluxes, s=1, color='r')\n",
@@ -141,7 +139,6 @@
     "* `astroquery.mast` : this makes it easy to query MAST for TESS data\n",
     "* `matplotlib` : we only do this import so that we can change the DPI below\n",
     "* `matplotlib.pyplot` : this gives us the tools for making pleasant-looking plots\n",
-    "* `s3.fs`: this lets us access the data stored in our cloud\n",
     "\n",
     "Below the imports, we make some minor adjustments to the DPI, to increase the resolution of our graphs, and \"enable cloud datasets\". This second piece is important: TIKE (the platform you're currently on) is hosted in the cloud. Reading data from our cloud archive is therefore much faster than trying to read from our servers in Baltimore."
    ]
@@ -160,7 +157,6 @@
     "\n",
     "import matplotlib as mpl\n",
     "import matplotlib.pyplot as plt\n",
-    "import s3fs\n",
     "\n",
     "mpl.rcParams['figure.dpi'] = 600\n",
     "Observations.enable_cloud_dataset()"
@@ -258,27 +254,6 @@
    "metadata": {},
    "source": [
     "### Reading a FITS File\n",
-    "The structure of FITS files can be unintuitive at first; but that's to be expected from a 40 year old file format! Let's take a look at a little bit of that now."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ab67757b-bfdd-452c-9ebb-5679c3bf63c5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "with fs.open(cloud_uri, 'rb') as f:\n",
-    "    fits.info(f)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cfbaa65f-a65d-4ccd-874b-4523e2187ac6",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
     "We're interested in the `LIGHTCURVE` data, which is on HDU (Header Data Unit) 1. HDU1 is broken up further, but it can be a bit confusing to look at. If you want, you can read all of the available columns in No. 1 by running the cell below; be forewarned that it's a lot of text!"
    ]
   },
@@ -292,10 +267,9 @@
    "outputs": [],
    "source": [
     "# Warning! This prints out a lot of text\n",
-    "with fs.open(cloud_uri, 'rb') as f:\n",
-    "    with fits.open(f, mode=\"readonly\") as hdulist:\n",
-    "        header1 = hdulist[1].header\n",
-    "        print(repr(header1))"
+    "with fits.open(cloud_uri, fsspec_kwargs={\"anon\": True}) as hdulist:\n",
+    "    header1 = hdulist[1].header\n",
+    "    print(repr(header1))"
    ]
   },
   {
@@ -317,11 +291,10 @@
    },
    "outputs": [],
    "source": [
-    "with fs.open(cloud_uri, 'rb') as f:\n",
-    "    with fits.open(f, mode=\"readonly\") as hdulist:\n",
-    "        tess_bjds = hdulist[1].data['TIME']\n",
-    "        sap_fluxes = hdulist[1].data['SAP_FLUX']\n",
-    "        pdcsap_fluxes = hdulist[1].data['PDCSAP_FLUX']"
+    "with fits.open(cloud_uri, fsspec_kwargs={\"anon\": True}) as hdulist:\n",
+    "    tess_bjds = hdulist[1].data['TIME']\n",
+    "    sap_fluxes = hdulist[1].data['SAP_FLUX']\n",
+    "    pdcsap_fluxes = hdulist[1].data['PDCSAP_FLUX']"
    ]
   },
   {
@@ -410,7 +383,6 @@
     "\n",
     "**Author:** Thomas Dutkiewicz <br>\n",
     "**Keywords:** TIKE, AWS Cloud, Light curves <br>\n",
-    "**Last Updated:** Apr 2024 <br>\n",
     "***\n",
     "[Top of Page](#top)\n",
     "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "


### PR DESCRIPTION
this includes

- the notebook specifications for the 2025.07 beta release
- updates to the s3 access routine, which was out of date for these notebooks
- removing the "last updated" date on the introduction page, which was not helpful
- requirements files for the four notebooks